### PR TITLE
Fix PyPI publish workflow with token authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,27 +16,22 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/macscribe
-    permissions:
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
 
+      - name: Set up Python
+        run: uv python install 3.12
+
       - name: Build package
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish --token $PYPI_API_TOKEN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "macscribe"
-version = "0.1.3"
+version = "0.1.4"
 description = "Add your description here"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Switch from trusted publishing to API token authentication for PyPI
- Remove environment and id-token permissions that require trusted publisher setup
- Use `uv publish --token` instead of `pypa/gh-action-pypi-publish` action
- Bump version to 0.1.4 for testing

## Problem
The previous workflow used trusted publishing which requires complex setup on PyPI. This caused authentication failures with error: `invalid-publisher: valid token, but no corresponding publisher`.

## Solution
Switch to the simpler API token approach (same as the copcon project) which only requires setting the `PYPI_API_TOKEN` secret in GitHub.

## Test plan
- [ ] Ensure `PYPI_API_TOKEN` secret is set in GitHub repository settings
- [ ] Merge this PR to trigger the publish workflow
- [ ] Verify successful publication to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)